### PR TITLE
Hide all symbols for assimp

### DIFF
--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -161,7 +161,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #   define AI_WONT_RETURN
 
-#   define ASSIMP_API __attribute__ ((visibility("default")))
+#   define ASSIMP_API __attribute__ ((visibility("hidden")))
 #   define ASSIMP_API_WINONLY
 #   define AI_FORCE_INLINE inline
 #endif // (defined _MSC_VER)


### PR DESCRIPTION
The runtime hides all symbols with the exception of the c_api interface.
Assimp has a hardcoded call to specifically unhide symbols. Change visibility
to hidden.

vTest: http://runtime-test.esri.com:8080/view/vTest/job/vtest-3rdparty_libraries-interface/400/downstreambuildview/ http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-interface/5121/downstreambuildview/