### PR TITLE
Get file size from IOStream

### DIFF
--- a/code/Common/Importer.cpp
+++ b/code/Common/Importer.cpp
@@ -627,7 +627,14 @@ const aiScene* Importer::ReadFile( const char* _pFile, unsigned int pFlags)
         uint32_t fileSize = 0;
         if (fileIO)
         {
-            fileSize = boost::filesystem::file_size(pFile);
+            if (fileIO->FileSize() > 0)
+            {
+                fileSize = fileIO->FileSize();
+            }
+            else
+            {
+                fileSize = boost::filesystem::file_size(pFile);
+            }
             pimpl->mIOHandler->Close( fileIO );
         }
 


### PR DESCRIPTION
When loading a file from raw memory instead of
from a file path, assimp still used boost::filesystem::file_size
to get the file size. This crashed because the file
path did not exist.

This commit uses the size in the IOStream instead.

Issue: https://devtopia.esri.com/runtime/orion/issues/345