### PR TITLE
build: Change the rapidjson include path to external

### DIFF
--- a/assimp.lua
+++ b/assimp.lua
@@ -73,17 +73,16 @@ project "assimp"
     "code/**.hpp",
     "contrib/irrXML/irrXML.h", -- Required by Collada (DAE) reader
     "contrib/irrXML/irrXML.cpp",
-    "contrib/rapidjson/include/**.h",
   }
 
   includedirs {
-    "include",
+    _3RDPARTY_DIR .. "/boost",
+    _3RDPARTY_DIR .. "/rapidjson/include",
+    _3RDPARTY_DIR .. "/zlib",
     "code",
     "contrib/irrXML",
-    "contrib/rapidjson/include",
+    "include",
     prjDir,
-    prjDir .. "/../boost",
-    prjDir .. "/../zlib",
   }
 
   -- -------------------------------------------------------------


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/537
vTest 3rdparty: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/588/downstreambuildview/
vTest RTC: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/14086/downstreambuildview/

The rapidjson library is being added to the runtime 3rdparty list.
Switch assimp to use the external rapidjson instead of the internal
version.