### PR TITLE
Hide all symbols for assimp

### DIFF
--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -160,7 +160,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #elif defined(SWIG)
 /* Do nothing, the relevant defines are all in AssimpSwigPort.i */
 #else
-#define ASSIMP_API __attribute__((visibility("default")))
+#define ASSIMP_API __attribute__((visibility("hidden")))
 #define ASSIMP_API_WINONLY
 #endif // _WIN32
 


### PR DESCRIPTION
Set assimp symbol visibility to hidden. Originally done [here](https://github.com/Esri/assimp/pull/3), but lost during the update to 5.1.6. 

3rdparty vTest build: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/445/downstreambuildview/

vTest with custom 3rdparty: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29310/downstreambuildview/