### PR TITLE
rtc: Add the new zlib minizip include path

### DIFF
--- a/assimp.lua
+++ b/assimp.lua
@@ -67,6 +67,7 @@ includedirs {
   _3RDPARTY_DIR .. "/boost",
   _3RDPARTY_DIR .. "/rapidjson/include",
   _3RDPARTY_DIR .. "/zlib",
+  _3RDPARTY_DIR .. "/zlib/contrib/minizip",
 }
 
 files {


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1560

This updates the include folders needed to find our zlib library