### PR TITLE
Read MSFT_lods

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1628,6 +1628,22 @@ inline void Node::Read(Value &obj, Asset &r) {
                 }
             }
         }
+
+        // Read the the nodes specified under MSFT_lod extension ids and save as children node
+        if (Value *msftLodExt = FindObject(*curExtensions, "MSFT_lod")) {
+            if (Value *lodIds = FindArray(*msftLodExt, "ids")) {
+                for (unsigned int i = 0; i < lodIds->Size(); ++i) {
+                    Value &child = (*lodIds)[i];
+                    if (child.IsUint()) {
+                        // get/create the lod id as child node
+                        Ref<Node> chn = r.nodes.Retrieve(child.GetUint());
+                        if (chn) {
+                            this->children.push_back(chn);
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/orion/issues/1453

Changes:
Assimp reads the MSFT_lod extension and publically stores the following information on the Node's metadata:
```
{
            "extensions": {
                "MSFT_lod": {
                    "ids": [1, 2]
                }
            }
```
However the actual nodes(i.e.[1, 2]) are not stored anywhere and we cannot access them from the scene object. As part of this change: 
- Update the `Node::Read` method to read the `ids for MSFT_lod` from `Node's json`. 
- Retrieve the corresponding Nodes from glTF Asset
- Save the retrieved node as children node

These nodes can then be read from scene and matched against the metadata stored on node as extension