### PR TITLE
Expose Extras on glTF material:

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -400,6 +400,8 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
             aimat->AddProperty(&emissiveStrength.emissiveStrength, 1, AI_MATKEY_EMISSIVE_INTENSITY);
         }
 
+        // This is ESRI runtimcore implementation to support the extras and extensions on material.
+        // Reading the extras and extensions follows the same pattern used for NODE.
         if (mat.customExtensions || mat.extras.HasExtras()) {
             aimat->mMetaData = new aiMetadata;
             if (mat.customExtensions) {

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -239,6 +239,32 @@ inline void SetMaterialTextureProperty(std::vector<int> &embeddedTexIdxs, Asset 
     }
 }
 
+void ParseExtensions(aiMetadata *metadata, const CustomExtension &extension) {
+    if (extension.mStringValue.isPresent) {
+        metadata->Add(extension.name, aiString(extension.mStringValue.value));
+    } else if (extension.mDoubleValue.isPresent) {
+        metadata->Add(extension.name, extension.mDoubleValue.value);
+    } else if (extension.mUint64Value.isPresent) {
+        metadata->Add(extension.name, extension.mUint64Value.value);
+    } else if (extension.mInt64Value.isPresent) {
+        metadata->Add(extension.name, static_cast<int32_t>(extension.mInt64Value.value));
+    } else if (extension.mBoolValue.isPresent) {
+        metadata->Add(extension.name, extension.mBoolValue.value);
+    } else if (extension.mValues.isPresent) {
+        aiMetadata val;
+        for (auto const &subExtension : extension.mValues.value) {
+            ParseExtensions(&val, subExtension);
+        }
+        metadata->Add(extension.name, val);
+    }
+}
+
+void ParseExtras(aiMetadata *metadata, const Extras &extras) {
+    for (auto const &value : extras.mValues) {
+        ParseExtensions(metadata, value);
+    }
+}
+
 static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, Material &mat) {
     aiMaterial *aimat = new aiMaterial();
 
@@ -372,6 +398,16 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
             MaterialEmissiveStrength &emissiveStrength = mat.materialEmissiveStrength.value;
 
             aimat->AddProperty(&emissiveStrength.emissiveStrength, 1, AI_MATKEY_EMISSIVE_INTENSITY);
+        }
+
+        if (mat.customExtensions || mat.extras.HasExtras()) {
+            aimat->mMetaData = new aiMetadata;
+            if (mat.customExtensions) {
+                ParseExtensions(aimat->mMetaData, mat.customExtensions);
+            }
+            if (mat.extras.HasExtras()) {
+                ParseExtras(aimat->mMetaData, mat.extras);
+            }
         }
 
         return aimat;
@@ -1089,32 +1125,6 @@ static void BuildVertexWeightMapping(Mesh::Primitive &primitive, std::vector<std
 
 static std::string GetNodeName(const Node &node) {
     return node.name.empty() ? node.id : node.name;
-}
-
-void ParseExtensions(aiMetadata *metadata, const CustomExtension &extension) {
-    if (extension.mStringValue.isPresent) {
-        metadata->Add(extension.name, aiString(extension.mStringValue.value));
-    } else if (extension.mDoubleValue.isPresent) {
-        metadata->Add(extension.name, extension.mDoubleValue.value);
-    } else if (extension.mUint64Value.isPresent) {
-        metadata->Add(extension.name, extension.mUint64Value.value);
-    } else if (extension.mInt64Value.isPresent) {
-        metadata->Add(extension.name, static_cast<int32_t>(extension.mInt64Value.value));
-    } else if (extension.mBoolValue.isPresent) {
-        metadata->Add(extension.name, extension.mBoolValue.value);
-    } else if (extension.mValues.isPresent) {
-        aiMetadata val;
-        for (auto const &subExtension : extension.mValues.value) {
-            ParseExtensions(&val, subExtension);
-        }
-        metadata->Add(extension.name, val);
-    }
-}
-
-void ParseExtras(aiMetadata* metadata, const Extras& extras) {
-    for (auto const &value : extras.mValues) {
-        ParseExtensions(metadata, value);
-    }
 }
 
 aiNode *glTF2Importer::ImportNode(glTF2::Asset &r, glTF2::Ref<glTF2::Node> &ptr) {

--- a/code/Material/MaterialSystem.cpp
+++ b/code/Material/MaterialSystem.cpp
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/ParsingUtils.h>
 #include <assimp/fast_atof.h>
 #include <assimp/material.h>
+#include <assimp/metadata.h>
 #include <assimp/types.h>
 #include <assimp/DefaultLogger.hpp>
 #include <memory>

--- a/code/Material/MaterialSystem.cpp
+++ b/code/Material/MaterialSystem.cpp
@@ -421,6 +421,13 @@ unsigned int aiGetMaterialTextureCount(const C_STRUCT aiMaterial *pMat, C_ENUM a
     return max;
 }
 
+// ---------------------------------------------------------------------------
+// Get the metadata for the material
+C_STRUCT aiMetadata *aiGetMaterialMetadata(const C_STRUCT aiMaterial *pMat) {
+    ai_assert(pMat != nullptr);
+    return pMat->mMetaData;
+}
+
 // ------------------------------------------------------------------------------------------------
 aiReturn aiGetMaterialTexture(const C_STRUCT aiMaterial *mat,
         aiTextureType type,
@@ -478,7 +485,7 @@ static const unsigned int DefaultNumAllocated = 5;
 // ------------------------------------------------------------------------------------------------
 // Construction. Actually the one and only way to get an aiMaterial instance
 aiMaterial::aiMaterial() :
-        mProperties(nullptr), mNumProperties(0), mNumAllocated(DefaultNumAllocated) {
+        mProperties(nullptr), mNumProperties(0), mNumAllocated(DefaultNumAllocated), mMetaData(nullptr) {
     // Allocate 5 entries by default
     mProperties = new aiMaterialProperty *[DefaultNumAllocated];
 }
@@ -488,6 +495,7 @@ aiMaterial::~aiMaterial() {
     Clear();
 
     delete[] mProperties;
+    delete mMetaData;
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -52,6 +52,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/types.h>
 
+#include <assimp/metadata.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -833,6 +835,16 @@ public:
             aiTextureOp *op = NULL,
             aiTextureMapMode *mapmode = NULL) const;
 
+    // -------------------------------------------------------------------
+    /** Helper function to get Metadata associated with this material or nullptr if there is no metadata.
+     *  Whether any metadata is generated depends on the source file format. See the
+     * @link importer_notes @endlink page for more information on every source file
+     * format. Importers that don't document any metadata don't write any.
+     * e.g. you can get information stored in Extras and custom Extensions for materials in glTF models
+     * @return metadata for this material
+     */
+    C_STRUCT aiMetadata *GetMetadata() const;
+
     // Setters
 
     // ------------------------------------------------------------------------------
@@ -956,6 +968,9 @@ public:
 
     /** Storage allocated */
     unsigned int mNumAllocated;
+
+    /** Metadata associated with this material or nullptr if there is no metadata.*/
+    C_STRUCT aiMetadata *mMetaData;
 };
 
 // Go back to extern "C" again
@@ -1632,6 +1647,16 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialString(const C_STRUCT aiMaterial *pMat,
 // ---------------------------------------------------------------------------
 ASSIMP_API unsigned int aiGetMaterialTextureCount(const C_STRUCT aiMaterial *pMat,
         C_ENUM aiTextureType type);
+
+// ---------------------------------------------------------------------------
+/** Helper function to get Metadata associated with this material or nullptr if there is no metadata.
+ *  Whether any metadata is generated depends on the source file format. See the
+ * @link importer_notes @endlink page for more information on every source file
+ * format. Importers that don't document any metadata don't write any.
+ * e.g. you can get information stored in Extras for glTF models
+ * @return metadata for this material
+ */
+ASSIMP_API C_STRUCT aiMetadata *aiGetMaterialMetadata(const C_STRUCT aiMaterial *pMat);
 
 // ---------------------------------------------------------------------------
 /** @brief Helper function to get all values pertaining to a particular

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/types.h>
 
-#include <assimp/metadata.h>
+struct aiMetadata;
 
 #ifdef __cplusplus
 extern "C" {
@@ -836,12 +836,14 @@ public:
             aiTextureMapMode *mapmode = NULL) const;
 
     // -------------------------------------------------------------------
-    /** Helper function to get Metadata associated with this material or nullptr if there is no metadata.
+    /** This is ESRI runtimcore implementation to support the extras and extensions from material.
+     *
+     *  Helper function to get Metadata associated with this material or nullptr if there is no metadata.
      *  Whether any metadata is generated depends on the source file format. See the
-     * @link importer_notes @endlink page for more information on every source file
-     * format. Importers that don't document any metadata don't write any.
-     * e.g. you can get information stored in Extras and custom Extensions for materials in glTF models
-     * @return metadata for this material
+     *  @link importer_notes @endlink page for more information on every source file
+     *  format. Importers that don't document any metadata don't write any.
+     *  e.g. you can get information stored in Extras and custom Extensions for materials in glTF models
+     *  @return metadata for this material
      */
     C_STRUCT aiMetadata *GetMetadata() const;
 
@@ -969,7 +971,7 @@ public:
     /** Storage allocated */
     unsigned int mNumAllocated;
 
-    /** Metadata associated with this material or nullptr if there is no metadata.*/
+    /** Metadata associated with this material or nullptr if there is no metadata. Added by ESRI runtimecore to support Extras and Extensions */
     C_STRUCT aiMetadata *mMetaData;
 };
 

--- a/include/assimp/material.inl
+++ b/include/assimp/material.inl
@@ -79,6 +79,11 @@ AI_FORCE_INLINE unsigned int aiMaterial::GetTextureCount(aiTextureType type) con
 }
 
 // ---------------------------------------------------------------------------
+AI_FORCE_INLINE C_STRUCT aiMetadata *aiMaterial::GetMetadata() const {
+    return ::aiGetMaterialMetadata(this);
+}
+
+// ---------------------------------------------------------------------------
 template <typename Type>
 AI_FORCE_INLINE aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
         unsigned int idx, Type* pOut,


### PR DESCRIPTION
This PR makes following changes to read extras and extensions from glTF material:

When Node reads the associated material it invokes `inst->ReadExtensions(obj) and inst->ReadExtras(obj)` from [Ref<T> LazyDict<T>::Retrieve(unsigned int i)](https://github.com/Esri/assimp/blob/master/code/AssetLib/glTF2/glTF2Asset.inl#L511). This stores the extra and extension values on the `glTF::Material` object as `std::vector<CustomExtension>`. This is same on all the glTF object because `ReadExtensions(obj) and and ReadExtras(obj)` is on the base class for all glTF objects.

Now `glTF::Node` already takes this extra and extension information and store it as aiMetada on public aiNode object in `glTF2Importer::ImportNode(...)`. We now follow the similar pattern and take the extra and extension information from glTF::Material and store it on public interface of assimp i.e. aiMaterial in`glTF2Importer::ImportMaterial(...)` .

- Add aiMetaData member to aiMaterial object
- Expose a method to access metaData
- Store Extras and Custom Extension in aiMaterial  metadata in glTF2Importer

3rd Party vtest: 
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1257/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1258/downstreambuildview/