### PR TITLE
Fix collada uv channels  mapping

### DIFF
--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -2292,9 +2292,9 @@ void ColladaParser::ReadNodeGeometry(XmlNode &node, Node *pNode) {
                             urlMat++;
 
                         s.mMatName = urlMat;
+                        ReadMaterialVertexInputBinding(instanceMatNode, s);
                         // store the association
                         instance.mMaterials[group] = s;
-                        ReadMaterialVertexInputBinding(instanceMatNode, s);
                     }
                 }
             }


### PR DESCRIPTION

- UV Channel to texture mapping information for collada models was fixed as part of this [this PR](https://github.com/assimp/assimp/pull/5630) in assimp main public repository in v5.4.3.

- This change is addressing the  [issue reported in runtime](https://devtopia.esri.com/runtime/orion/issues/1673) which is same as [original issue in assimp ](https://github.com/assimp/assimp/issues/5631). 

- When we upgraded to v5.4.3 we missed this fix in our merge conflicts. 
- This PR cherry picks the original fix and adds it to our repo.