### PR TITLE
assimp: support normalized morph weights and rotations

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -567,7 +567,7 @@ struct Accessor : public Object {
     std::vector<double> min; //!< Minimum value of each component in this attribute.
     std::unique_ptr<Sparse> sparse;
     std::unique_ptr<Buffer> decodedBuffer; // Packed decoded data, returned instead of original bufferView if present
-
+    bool normalized;
     unsigned int GetNumComponents();
     unsigned int GetBytesPerComponent();
     unsigned int GetElementSize();

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -883,6 +883,7 @@ inline void Accessor::Read(Value &obj, Asset &r) {
 
     byteOffset = MemberOrDefault(obj, "byteOffset", size_t(0));
     componentType = MemberOrDefault(obj, "componentType", ComponentType_BYTE);
+    normalized = MemberOrDefault(obj, "normalized", false);
     {
         const Value *countValue = FindUInt(obj, "count");
         if (!countValue) {

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -60,6 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/Importer.hpp>
 
+#include <array>
 #include <memory>
 #include <unordered_map>
 
@@ -507,6 +508,49 @@ aiColor4D *GetVertexColorsForType(Ref<Accessor> input, std::vector<unsigned int>
                 colors[i].b / max, colors[i].a / max);
     }
     delete[] colors;
+    return output;
+}
+
+template <typename T>
+aiQuaternion *GetQuaternionsForType(Ref<Accessor> input) {
+    constexpr float max = std::numeric_limits<T>::max();
+    std::array<T, 4> *quats;
+    input->ExtractData(quats);
+    auto output = new aiQuaternion[input->count];
+    if constexpr (std::is_signed_v<T>) {
+        for (size_t i = 0; i < input->count; i++) {
+            output[i] = aiQuaternion(
+                    std::max(quats[i][0] / max, -1.0F), std::max(quats[i][1] / max, -1.0F),
+                    std::max(quats[i][2] / max, -1.0F), std::max(quats[i][3] / max, -1.0F));
+        }
+    } else {
+        for (size_t i = 0; i < input->count; i++) {
+            output[i] = aiQuaternion(
+                    quats[i][0] / max, quats[i][1] / max,
+                    quats[i][2] / max, quats[i][3] / max);
+        }
+    }
+    delete[] quats;
+    return output;
+}
+
+template <typename T>
+float *GetMorphWeightsForType(Ref<Accessor> input) {
+    constexpr float max = std::numeric_limits<T>::max();
+    T *weights;
+    input->ExtractData(weights);
+    auto output = new float[input->count];
+    if constexpr (std::is_signed_v<T>) {
+            for (size_t i = 0; i < input->count; i++) {
+                output[i] = std::max(weights[i] / max, -1.0F);
+            }
+        }
+    else {
+        for (size_t i = 0; i < input->count; i++) {
+            output[i] = weights[i] / max;
+        }
+    }
+    delete[] weights;
     return output;
 }
 
@@ -1372,7 +1416,25 @@ aiNodeAnim *CreateNodeAnim(glTF2::Asset &, Node &node, AnimationSamplers &sample
             float *times = nullptr;
             samplers.rotation->input->ExtractData(times);
             aiQuaternion *values = nullptr;
-            samplers.rotation->output->ExtractData(values);
+
+            if (samplers.rotation->output->normalized) {
+                if (samplers.rotation->output->componentType == ComponentType_BYTE) {
+                    values = GetQuaternionsForType<char>(samplers.rotation->output);
+                } else if (samplers.rotation->output->componentType == ComponentType_UNSIGNED_BYTE) {
+                    values = GetQuaternionsForType<unsigned char>(samplers.rotation->output);
+                } else if (samplers.rotation->output->componentType == ComponentType_SHORT) {
+                    values = GetQuaternionsForType<short>(samplers.rotation->output);
+                } else if (samplers.rotation->output->componentType == ComponentType_UNSIGNED_SHORT) {
+                    values = GetQuaternionsForType<unsigned short>(samplers.rotation->output);
+                } else  {
+                    throw DeadlyImportError("GLTF: Invalid component type for normalized quaternion ", ai_to_string(samplers.rotation->output->componentType));
+                }
+            } else if (samplers.rotation->output->componentType == ComponentType_FLOAT) {
+                samplers.rotation->output->ExtractData(values);
+            } else {
+                throw DeadlyImportError("GLTF: Invalid component type for quaternion ", ai_to_string(samplers.rotation->output->componentType));
+            }
+
             anim->mNumRotationKeys = static_cast<unsigned int>(samplers.rotation->input->count);
             anim->mRotationKeys = new aiQuatKey[anim->mNumRotationKeys];
             unsigned int ii = (samplers.rotation->interpolation == Interpolation_CUBICSPLINE) ? 1 : 0;
@@ -1439,7 +1501,27 @@ aiMeshMorphAnim *CreateMeshMorphAnim(glTF2::Asset &, Node &node, AnimationSample
             float *times = nullptr;
             samplers.weight->input->ExtractData(times);
             float *values = nullptr;
-            samplers.weight->output->ExtractData(values);
+
+            if (samplers.weight->output->normalized)
+            {
+                if (samplers.weight->output->componentType == ComponentType_BYTE) {
+                    values = GetMorphWeightsForType<char>(samplers.weight->output);
+                } else if (samplers.weight->output->componentType == ComponentType_UNSIGNED_BYTE) {
+                    values = GetMorphWeightsForType<unsigned char>(samplers.weight->output);
+                } else if (samplers.weight->output->componentType == ComponentType_SHORT) {
+                    values = GetMorphWeightsForType<short>(samplers.weight->output);
+                } else if (samplers.weight->output->componentType == ComponentType_UNSIGNED_SHORT) {
+                    values = GetMorphWeightsForType<unsigned short>(samplers.weight->output);
+                } else {
+                    throw DeadlyImportError("GLTF: Invalid component type for normalized morph weights ", ai_to_string(samplers.weight->output->componentType));
+                }
+            
+            } else if (samplers.weight->output->componentType == ComponentType_FLOAT) {
+                samplers.weight->output->ExtractData(values);
+            } else {
+                throw DeadlyImportError("GLTF: Invalid component type for morph weights ", ai_to_string(samplers.weight->output->componentType));
+            }
+           
             anim->mNumKeys = static_cast<uint32_t>(samplers.weight->input->count);
 
             // for Interpolation_CUBICSPLINE can have more outputs


### PR DESCRIPTION

[GLTF 2.0 standard](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html) says `weights` and `rotations` could be normalized type.  Assimp doesn't support it. 

The branch is to add support of normalized morph weights and rotations

<img width="1928" height="1044" alt="GLTF" src="https://github.com/user-attachments/assets/91573aac-2272-4dc3-9ca1-573fd394bade" />


